### PR TITLE
feat: improve gallery layout and mobile view

### DIFF
--- a/components/gallery.tsx
+++ b/components/gallery.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
-import { motion } from "framer-motion";
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 
 const images = [
   { src: "/images/thumbnail.png", caption: "Nuestro primer rawr 🦕" },
@@ -14,6 +14,11 @@ const images = [
 ];
 
 export default function Gallery() {
+  const [selected, setSelected] = useState<{
+    src: string;
+    caption: string;
+  } | null>(null);
+
   return (
     <section className="w-full">
       <h2 className="text-3xl font-bold text-center mb-8">Galería de Momentos</h2>
@@ -21,18 +26,23 @@ export default function Gallery() {
         {images.map((img, idx) => (
           <motion.div
             key={idx}
-            className="relative overflow-hidden rounded-xl shadow-md"
+            className="relative overflow-hidden rounded-xl shadow-md aspect-[3/4]"
             whileHover={{ rotate: 2, scale: 1.05 }}
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.3 }}
+            onClick={() => {
+              if (typeof window !== "undefined" && window.innerWidth < 640) {
+                setSelected(img);
+              }
+            }}
           >
             <Image
               src={img.src}
               alt={img.caption}
-              width={400}
-              height={300}
+              width={300}
+              height={400}
               className="object-cover w-full h-full"
             />
             <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-xs p-2">
@@ -41,11 +51,34 @@ export default function Gallery() {
           </motion.div>
         ))}
       </div>
-      <div className="text-center mt-8">
-        <Link href="/gallery" className="text-primary underline">
-          Ver más aventuras
-        </Link>
-      </div>
+
+      <AnimatePresence>
+        {selected && (
+          <motion.div
+            className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/80 sm:hidden"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={() => setSelected(null)}
+          >
+            <div className="absolute inset-0 pointer-events-none flex flex-wrap items-center justify-center text-6xl gap-4 opacity-20">
+              <span>🦖</span>
+              <span>🦕</span>
+              <span>🦙</span>
+            </div>
+            <div className="relative z-10 max-h-[80vh] w-auto p-4">
+              <Image
+                src={selected.src}
+                alt={selected.caption}
+                width={400}
+                height={600}
+                className="object-contain w-full h-full"
+              />
+              <p className="mt-2 text-center text-white">{selected.caption}</p>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- adjust gallery grid for vertical photos
- add mobile full-screen viewer with dinosaur and llama background
- remove link to separate gallery page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b060bf9e5083318108bc9fd90e2e92